### PR TITLE
Change giscus from repo `beatrizmilz/blog-en` to `JaumeAmoresDS/home`

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -25,4 +25,4 @@ format:
     css: styles.css
 comments:
   giscus:
-    repo: beatrizmilz/blog-en
+    repo: JaumeAmoresDS/home


### PR DESCRIPTION
Hi @JaumeAmoresDS !

I received a notification from a blogpost in a repo of mine, but it's from your blog:
https://github.com/beatrizmilz/blog-en/discussions/32#discussioncomment-12542375

I'm sending a PR with a small change to fix this. 
It is also important that you **activate the discussions in this repository** (you can do that on the settings of the repository), and configure giscus in this page: https://giscus.app/

You can check the steps here:
- https://quarto.org/docs/output-formats/html-basics.html#commenting
- https://giscus.app/

I hope this helps!

Best regards,

Bea 

